### PR TITLE
Added a formula for use with Homebrew.

### DIFF
--- a/vobsub2srt.rb
+++ b/vobsub2srt.rb
@@ -1,0 +1,15 @@
+require 'formula'
+
+class Vobsub2srt < Formula
+  head 'git://github.com/ruediger/VobSub2SRT.git', :using => :git
+  homepage 'https://github.com/ruediger/VobSub2SRT'
+
+  depends_on 'cmake'
+  depends_on 'tesseract'
+  depends_on 'ffmpeg'
+
+  def install
+    system "./configure #{std_cmake_parameters}"
+    system "cd build; make install"
+  end
+end


### PR DESCRIPTION
This formula can be included directly by supplying the URL to the
formula to the brew command on os x.

Currently you can install this on in Homebrew on os x using the command.

```
 brew install https://github.com/jimmyharris/VobSub2SRT/raw/master/vobsub2srt.rb
```

If you accept this the command becomes: 

```
 brew install https://github.com/jimmyharris/VobSub2SRT/raw/master/vobsub2srt.rb
```
