### PR TITLE
Build fails because include path isn't set in Makefiles

### DIFF
--- a/mplayer/CMakeLists.txt
+++ b/mplayer/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_definitions("-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -D_REENTRANT")
 add_definitions("-Wundef -Wall -Wno-switch -Wno-parentheses -Wpointer-arith -Wredundant-decls -Wstrict-prototypes -Wmissing-prototypes -Wdisabled-optimization -Wno-pointer-sign -Wdeclaration-after-statement")
 
+include_directories(${Libavutil_INCLUDE_DIRS})
+
 set(mplayer_sources
   mp_msg.c
   mp_msg.h


### PR DESCRIPTION
CMake doesn't set the gcc include path flag for libavutils. gcc can't find avutil.h and the build fails:

```
$ ./configure
-- The C compiler identification is GNU
-- The CXX compiler identification is GNU
-- Check for working C compiler: /usr/lib64/ccache/gcc
-- Check for working C compiler: /usr/lib64/ccache/gcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/lib64/ccache/c++
-- Check for working CXX compiler: /usr/lib64/ccache/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Source: /home/afleig/compile/VobSub2SRT
-- Binary: /home/afleig/compile/VobSub2SRT/build
-- Build type: Debug
-- checking for module 'libavutil'
--   found libavutil, version 51.9.1
-- Looking for include files CMAKE_HAVE_PTHREAD_H
-- Looking for include files CMAKE_HAVE_PTHREAD_H - found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE 
-- Performing Test TESSERACT_NAMESPACE
-- Performing Test TESSERACT_NAMESPACE - Success
-- Found Tesseract: /usr/lib64/libtesseract_api.so;/usr/lib64/libtiff.so 
-- vobsub2srt version: 2d8d1b0
-- dpkg not found: No package generation.
-- Configuring done
-- Generating done
-- Build files have been written to: /home/afleig/compile/VobSub2SRT/build

$ make
make -C build
make[1]: Entering directory `/home/afleig/compile/VobSub2SRT/build'
make[2]: Entering directory `/home/afleig/compile/VobSub2SRT/build'
make[3]: Entering directory `/home/afleig/compile/VobSub2SRT/build'
Scanning dependencies of target mplayer
make[3]: Leaving directory `/home/afleig/compile/VobSub2SRT/build'
make[3]: Entering directory `/home/afleig/compile/VobSub2SRT/build'
[ 14%] Building C object mplayer/CMakeFiles/mplayer.dir/mp_msg.c.o
[ 28%] Building C object mplayer/CMakeFiles/mplayer.dir/spudec.c.o
/home/afleig/compile/VobSub2SRT/mplayer/spudec.c:47:56: fatal error: libavutil/avutil.h: No such file or directory
compilation terminated.
make[3]: *** [mplayer/CMakeFiles/mplayer.dir/spudec.c.o] Error 1
make[3]: Leaving directory `/home/afleig/compile/VobSub2SRT/build'
make[2]: *** [mplayer/CMakeFiles/mplayer.dir/all] Error 2
make[2]: Leaving directory `/home/afleig/compile/VobSub2SRT/build'
make[1]: *** [all] Error 2
make[1]: Leaving directory `/home/afleig/compile/VobSub2SRT/build'
make: *** [all] Error 2

This is on Fedora 16, cmake 2.8.7
```

I changed CMakeLists.txt to set the include flag.
