### PR TITLE
remove trailing space/newlines from text

### DIFF
--- a/src/vobsub2srt.c++
+++ b/src/vobsub2srt.c++
@@ -257,6 +257,12 @@ int main(int argc, char **argv) {
         text = new char[sizeof(errormsg)];
         memcpy(text, errormsg, sizeof(errormsg));
       }
+      else {
+          size_t size = strlen(text);
+          while (size > 0 and isspace(text[--size])) {
+              text[size] = '\0';
+          }
+      }
       if(verb) {
         cout << sub_counter << " Text: " << text << endl;
       }


### PR DESCRIPTION
remove any trailing white space from text
before formating as srt. many subtitles
have trailing newlines resulting in an
srt with more than 2 newlines otherwise.
