### PR TITLE
Y-threshold option converts all palette entries below it to black.

### DIFF
--- a/mplayer/spudec.h
+++ b/mplayer/spudec.h
@@ -33,8 +33,8 @@ void spudec_draw(void *self, void (*draw_alpha)(int x0,int y0, int w,int h, unsi
 void spudec_draw_scaled(void *self, unsigned int dxs, unsigned int dys, void (*draw_alpha)(int x0,int y0, int w,int h, unsigned char* src, unsigned char *srca, int stride));
 int spudec_apply_palette_crop(void *self, uint32_t palette, int sx, int ex, int sy, int ey);
 void spudec_update_palette(void *self, unsigned int *palette);
-void *spudec_new_scaled(unsigned int *palette, unsigned int frame_width, unsigned int frame_height, uint8_t *extradata, int extradata_len);
-void *spudec_new(unsigned int *palette);
+void *spudec_new_scaled(unsigned int *palette, unsigned int frame_width, unsigned int frame_height, uint8_t *extradata, int extradata_len, unsigned int y_threshold);
+void *spudec_new(unsigned int *palette, unsigned int y_threshold);
 void spudec_free(void *self);
 void spudec_reset(void *self);	// called after seek
 int spudec_visible(void *self); // check if spu is visible

--- a/mplayer/vobsub.c
+++ b/mplayer/vobsub.c
@@ -946,7 +946,7 @@ int vobsub_parse_ifo(void* this, const char *const name, unsigned int *palette,
 }
 
 void *vobsub_open(const char *const name, const char *const ifo,
-                  const int force, void** spu)
+                  const int force, unsigned int y_threshold, void** spu)
 {
     unsigned char *extradata = NULL;
     unsigned int extradata_len = 0;
@@ -986,7 +986,7 @@ void *vobsub_open(const char *const name, const char *const ifo,
                 rar_close(fd);
             }
             if (spu)
-                *spu = spudec_new_scaled(vob->palette, vob->orig_frame_width, vob->orig_frame_height, extradata, extradata_len);
+                *spu = spudec_new_scaled(vob->palette, vob->orig_frame_width, vob->orig_frame_height, extradata, extradata_len, y_threshold);
             if (extradata)
                 free(extradata);
 

--- a/mplayer/vobsub.h
+++ b/mplayer/vobsub.h
@@ -25,7 +25,7 @@ extern "C" {
 
 extern int vobsub_id; // R: moved from mpcommon.h
 
-void *vobsub_open(const char *subname, const char *const ifo, const int force, void** spu);
+void *vobsub_open(const char *subname, const char *const ifo, const int force, unsigned int y_threshold, void** spu);
 void vobsub_reset(void *vob);
 int vobsub_parse_ifo(void* self, const char *const name, unsigned int *palette, unsigned int *width, unsigned int *height, int force, int sid, char *langid);
 int vobsub_get_packet(void *vobhandle, float pts,void** data, int* timestamp);

--- a/src/vobsub2srt.c++
+++ b/src/vobsub2srt.c++
@@ -102,6 +102,7 @@ int main(int argc, char **argv) {
   std::string blacklist;
   std::string tesseract_data_path = TESSERACT_DATA_PATH;
   int index = -1;
+  int y_threshold = 0;
 
   {
     cmd_options opts;
@@ -115,6 +116,7 @@ int main(int argc, char **argv) {
       add_option("tesseract-lang", tess_lang_user, "set tesseract language (Default: auto detect)").
       add_option("tesseract-data", tesseract_data_path, "path to tesseract data (Default: " TESSERACT_DATA_PATH ")").
       add_option("blacklist", blacklist, "Character blacklist to improve the OCR (e.g. \"|\\/`_~<>\")").
+      add_option("y-threshold", y_threshold, "Y (luminance) threshold below which colors treated as black (Default: 0)").
       add_unnamed(subname, "subname", "name of the subtitle files WITHOUT .idx/.sub ending! (REQUIRED)");
     if(not opts.parse_cmd(argc, argv) or subname.empty()) {
       return 1;
@@ -125,9 +127,14 @@ int main(int argc, char **argv) {
   verbose = verb; // mplayer verbose level
   mp_msg_init();
 
+  // Set Y threshold from command-line arg only if given
+  if (y_threshold) {
+    cout << "Using Y palette threshold: " << y_threshold << "\n";
+  }
+
   // Open the sub/idx subtitles
   spu_t spu;
-  vob_t vob = vobsub_open(subname.c_str(), ifo_file.empty() ? 0x0 : ifo_file.c_str(), 1, &spu);
+  vob_t vob = vobsub_open(subname.c_str(), ifo_file.empty() ? 0x0 : ifo_file.c_str(), 1, y_threshold, &spu);
   if(not vob or vobsub_get_indexes_count(vob) == 0) {
     cerr << "Couldn't open VobSub files '" << subname << ".idx/.sub'\n";
     return 1;


### PR DESCRIPTION
Adds new argument to command line but doesn't change default behaviour.

It sends the Y-threshold as an extra argument to the mplayer-related functions. If you'd prefer it be implemented differently let me know.