### PR TITLE
Skip invisible pictures

### DIFF
--- a/src/vobsub2srt.c++
+++ b/src/vobsub2srt.c++
@@ -256,6 +256,10 @@ int main(int argc, char **argv) {
         dump_pgm(subname, sub_counter, width, height, stride, image, image_size);
       }
 
+      // invisible (alpha==0) pictures get cropped to nothing, skip OCR
+      if (!width || !height)
+          continue;
+
 #ifdef CONFIG_TESSERACT_NAMESPACE
       char *text = tess_base_api.TesseractRect(image, 1, stride, 0, 0, width, height);
 #else


### PR DESCRIPTION
Pictures with all alpha=0 are common for some reason. These get cropped
down to zero height, then cause OCR failures.

This is likely to address some of the issues in #34. Cutting out everything less than 3 pixels or so in either dimension might be a more aggressive choice.