### PR TITLE
Remove deprecated std_cmake_parameters

### DIFF
--- a/packaging/vobsub2srt.rb
+++ b/packaging/vobsub2srt.rb
@@ -12,7 +12,7 @@ class Vobsub2srt < Formula
   depends_on 'ffmpeg'
 
   def install
-    system "./configure #{std_cmake_parameters}"
+    system "./configure #{std_cmake_args}"
     system "make install"
   end
 end


### PR DESCRIPTION
Homebrew has deprecated std_cmake_parameters and suggests std_cmake_args