### PR TITLE
Update Gentoo ebuild

### DIFF
--- a/packaging/vobsub2srt-9999.ebuild
+++ b/packaging/vobsub2srt-9999.ebuild
@@ -1,25 +1,26 @@
-# -*- mode:sh; -*-
-
-# See https://github.com/ruediger/VobSub2SRT/issues/13
-
 # Copyright 1999-2013 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="4"
-
-EGIT_REPO_URI="git://github.com/ruediger/VobSub2SRT.git"
-
-inherit cmake-utils git-2
-
-IUSE=""
+EAPI=6
 
 DESCRIPTION="Converts image subtitles created by VobSub (.sub/.idx) to .srt textual subtitles using tesseract OCR engine"
 HOMEPAGE="https://github.com/ruediger/VobSub2SRT"
+SRC_URI="https://github.com/ruediger/VobSub2SRT/archive/master.tar.gz ->
+${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
+IUSE=""
 
-RDEPEND=">=app-text/tesseract-2.04-r1
-    >=virtual/ffmpeg-0.6.90"
+RDEPEND="
+	>=app-text/tesseract-2.04-r1
+	>=virtual/ffmpeg-0.6.90
+"
+
 DEPEND="${RDEPEND}"
+
+src_unpack() {
+	unpack ${A}
+	mv VobSub2SRT-master "${S}" || die "unpack failed"
+}


### PR DESCRIPTION
The ebuild has been updated to make use of EAPI 6, and download the sources as a `.tar.gz` (compared to pulling it from `git`).

Additionally, I'm also incorporating the ebuild (and ebuilds for other releases) into https://github.com/scriptkitties/overlay (https://github.com/scriptkitties/overlay/pull/22).